### PR TITLE
Update godaddy.py

### DIFF
--- a/godaddy.py
+++ b/godaddy.py
@@ -44,7 +44,7 @@ def _update_dns(domain, token):
     record = {
         'name': subdomain,
         'data': token,
-        'ttl': 300,
+        'ttl': 600,
         'type': 'TXT'
     }
     result = client.update_record(zone, record)


### PR DESCRIPTION
GoDaddy API now requires a minimum TTL of 600.

See:
godaddypy.client.BadResponse: Response Data: {'code': 'INVALID_BODY', 'fields': [{'path': 'records[0].ttl', 'code': 'UNKNOWN_RESTRICTION', 'message': 'must have a minimum value of 600'}], 'responseModel': 'Error', 'message': "Request body doesn't fulfill schema, see details in `fields`"}