### PR TITLE
Closes #10 - Add .travis.yml and requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install:
+  - pip install -r requirements.txt
+script:
+  - make all

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # le-godaddy-dns
 
+[![Build Status](https://travis-ci.org/josteink/le-godaddy-dns.svg?branch=master)](https://travis-ci.org/josteink/le-godaddy-dns)
+
 le-godaddy-dns is a [Let's encrypt](https://letsencrypt.org/) module,
 designed to be used as a hook with
 [dehydrated](https://github.com/lukas2511/dehydrated) for

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2017.7.27.1
+chardet==3.0.4
+GoDaddyPy==2.2.5
+idna==2.6
+requests==2.18.4
+urllib3==1.22


### PR DESCRIPTION
This PR closes #10 issue by adding .travis.yml and requirements.txt

The versions of python that were added to travis are: `3.4`, `3.5` and `3.6`

The badge was also added to the README.md