### PR TITLE
Implement Interim solution for wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,13 @@ example.com
 ...
 ````
 
-This step is optional, but it's recommended for reduced runtime 
-if you have many subdomains. Dehydrated gives you the option to 
-update multiple subdomains at the same time and then verify them all 
-instead of updating and verifying each subdomain individually.
+This step is optional, but recommended for reduced runtime 
+if you have many domains (SAN Cert.). Dehydrated gives you the option to 
+process multiple domains in wall call to the hook script, saving 
+resource overhead and pauses for dns propagation with each call. 
+Note however, that Dehydrated will first populate all challenges
+before verifying them in a second loop. This was not always the case but was
+implemented to correct some edge failures.
 
 ````bash
 # open your config file for dehydrated
@@ -91,7 +94,7 @@ they are.
 You can put the last section in a script and add as a cronjob to
 ensure your certificates gets auto-renewed.
 
-You can optionally inspect that they look like they should
+You can optionally inspect thatsub they look like they should
 
 ````bash
 find . -name fullchain.pem -exec openssl x509 -in '{}' -text -noout \;
@@ -101,6 +104,19 @@ find . -name fullchain.pem -exec openssl x509 -in '{}' -subject -noout \;
 You may also decide to customize the `deploy_certificates` hook in
 `goddady.py` if you want the certificates automatically copied
 to another destination than the one provided by `letsencrypt.sh`.
+
+This program is designed presently to assume that users will be registering
+wildcard DNS which by best practice would register \*.foo.com and foo.com.
+If you are not requesting wildcard certs, you can disable this by setting
+the following in the top of godaddy.py (hard coded to False)
+````
+GDPY_NO_WILDCARDS = True 
+````
+Background: Due to limitations in GoDaddy API's, we must use their "Patch" 
+API which is essentially an add record call. By default, this will add new 
+records each time the script is called. Unfortunately, the "Update" API
+call does not work for wildcard certs if you need both \*.foo.com and foo.com
+in the cert.
 
 # Disclaimer
 

--- a/godaddy.py
+++ b/godaddy.py
@@ -7,31 +7,71 @@ from tld import get_tld
 import time
 import godaddypy
 
+# Override this to True, if you are not using wildcards and
+# . Do not want to have new records added in DNS
+GDPY_NO_WILDCARDS = False
+
 if "GD_KEY" not in os.environ:
     raise Exception("Missing Godaddy API-key in GD_KEY environment variable! Please register one at https://developer.godaddy.com/keys/")
 
 if "GD_SECRET" not in os.environ:
     raise Exception("Missing Godaddy API-secret in GD_SECRET environment variable! Please register one at https://developer.godaddy.com/keys/")
 
-api_key = os.environ["GD_KEY"]
-api_secret = os.environ["GD_SECRET"]
-my_acct = godaddypy.Account(api_key=api_key, api_secret=api_secret)
+my_acct = godaddypy.Account(
+    api_key=os.environ["GD_KEY"], 
+    api_secret=os.environ["GD_SECRET"]
+)
+
 client = godaddypy.Client(my_acct)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
-
 def _get_zone(domain):
     d = get_tld(domain,as_object=True,fix_protocol=True)
     return d.tld
-
 
 def _get_subdomain_for(domain, zone):
     subdomain = domain[0:(-len(zone)-1)]
     return subdomain
 
+def _add_dns_rec(domain, token, tries=0):
+    challengedomain = "_acme-challenge." + domain
+    logger.info(" + Adding TXT record for {0} to '{1}'.".format(challengedomain, token))
+    zone = _get_zone(challengedomain)
+    # logger.info("Zone to update: {0}".format(zone))
+    subdomain = _get_subdomain_for(challengedomain, zone)
+    # logger.info("Subdomain name: {0}".format(subdomain))
+
+    record = {
+        'name': subdomain,
+        'data': token,
+        'ttl': 600,
+        'type': 'TXT'
+    }
+    result=None
+    try:
+        result = client.add_record(zone, record)
+    except godaddypy.client.BadResponse as err:
+        msg=str(err)
+        if msg.find('DUPLICATE_RECORD') > -1:
+            logger.info(" + . Duplicate record found. Skipping.")
+            return
+        logger.warn("Error returned {0}.".format(err))
+    except Exception as err:
+        logger.warn("Error returned {0}.".format(err))
+
+    if result is not True:
+        logger.warn("Error updating record for domain {0}.".format(domain))
+        if tries < 3:
+            logger.warn("Will retry in 5 seconds...")
+            time.sleep(5)
+            _get_subdomain_for(domain, token, tries+1)
+        else:
+            logger.warn("Giving up after 3 tries...")
+    else:
+        logger.info(" + . Record added")
 
 def _update_dns(domain, token):
     challengedomain = "_acme-challenge." + domain
@@ -59,10 +99,18 @@ def _update_dns(domain, token):
 
 
 def create_txt_record(args):
+    global GDPY_NO_WILDCARDS
     for i in range(0, len(args), 3):
         domain, token = args[i], args[i+2]
-        _update_dns(domain, token)
+        if GDPY_NO_WILDCARDS:
+            _update_dns(domain, token)
+        else:
+            _add_dns_rec(domain, token)
+        # Sleep between calls to avoid godaddy rate limits
+        # Acccording to their docs its 60 calls per minute
+        time.sleep(1)
     # a sleep is needed to allow DNS propagation
+    logger.info(" + Sleeping to wait for DNS propagation")
     time.sleep(30)
 
 
@@ -75,7 +123,7 @@ def delete_txt_record(args):
         if domain == "":
             logger.warn("Error deleting record, the domain argument is empty")
         else:
-            _update_dns(domain, "null")
+            _update_dns(domain, "(le_godaddy_dns) please delete me")
 
 
 def deploy_cert(args):


### PR DESCRIPTION
1) Implement "_add_dns_rec" procedure using patch API in GoDaddy (add)
2) Add a global variable to enable disabling of "add" record API call
 - Future version will implement a configurable using dehydrated config file
3) Minor clean up in top init code
4) Add message before long time.sleep() call
5) Put more descriptive value into dns record after completion instead of null
 - My coding preference is to avoid "nul"l values in any properly functioning logic or outputs