### PR TITLE
Fix for CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ chardet==3.0.4
 GoDaddyPy==2.2.6
 idna==2.6
 requests==2.20.0
-urllib3==1.23
+urllib3>=1.24.2
 tld>=0.8


### PR DESCRIPTION
Upgrade urllib3 to version 1.24.2 or later. For example:

urllib3>=1.24.2
Always verify the validity and compatibility of suggestions with your codebase.

Details

CVE-2019-11324 More information

high severity
Vulnerable versions: < 1.24.2
Patched version: 1.24.2
The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.