### PR TITLE
Add changes to mitigate issue #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,21 @@ nano $ROOTDIR/dehydrated/config
 HOOK_CHAIN="yes"
 ````
 
-### Convigure Godaddy Auth API Keys as Environment Variables:
+### Configure Godaddy Auth API Keys as Environment Variables:
 
 ````bash
+# configure your API keys
 export GD_KEY=your_key_here
 export GD_SECRET=your_secret_here
 ````
 
+#### Other Options
+`GODADDY_DNS_SLEEP` - override [default TXT update wait time](https://github.com/josteink/le-godaddy-dns/issues/141) in seconds (default/min is 30s)
+````bash
+export GODADDY_DNS_SLEEP=60
+````
+
+### Running The Script
 
 Now you need to configure `le-godaddy-dns` and retrieve your certs.
 

--- a/godaddy.py
+++ b/godaddy.py
@@ -106,8 +106,16 @@ def create_txt_record(args):
     for i in range(0, len(args), 3):
         domain, token = args[i], args[i+2]
         _set_token_in_dns(domain, token)
-    logger.info(" + Sleeping to wait for DNS propagation")
-    time.sleep(30)
+
+    GODADDY_DNS_SLEEP = 30
+    try:
+        _tmp = int(os.environ["GODADDY_DNS_SLEEP"])
+        if _tmp > GODADDY_DNS_SLEEP: GODADDY_DNS_SLEEP = _tmp
+    except Exception as ex:
+        pass
+
+    logger.info(f" + Sleeping for {GODADDY_DNS_SLEEP}s to wait for DNS propagation")
+    time.sleep(GODADDY_DNS_SLEEP)
 
 
 def delete_txt_record(args):


### PR DESCRIPTION
As this utility runs, it needs to set a TXT flag in the DNS infrastructure to allow LetsEncrypt to validate the certificate. Up until recently we had a 30 second wait time for this TXT flag to propagate and for the last several years, this had worked out well.

However, in a recent batch of certificates generated, I noticed errors from Dehydrated that the TXT key is invalid and was still showing the old (please delete me) value. It appears that some change(s) in GoDaddy's infrastructure causes some delays that were not seen before.

Re: Issue #141 